### PR TITLE
Make matchHeard() more flexible.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from pip.req import parse_requirements
 setup(
   name = 'Kodi-Voice',
   packages = ['kodi_voice'],
-  version = '0.7.9',
+  version = '0.8.0',
   description = 'A library for interfacing with Kodi with VUI platforms like Amazon Alexa, Google Home, and Cortana.',
   author = 'Joe Ipson',
   author_email = 'joe@ipson.me',
@@ -13,6 +13,6 @@ setup(
   include_package_data = True,
   keywords = ['kodi', 'voice', 'alexa'],
   classifiers = [],
-  download_url = 'https://github.com/m0ngr31/kodi-voice/tarball/0.7.9',
+  download_url = 'https://github.com/m0ngr31/kodi-voice/tarball/0.8.0',
   install_requires = ['requests', 'ConfigParser', 'roman', 'fuzzywuzzy']
 )


### PR DESCRIPTION
Pass through the heard string with its original encoding.  Tries first to simple match the input as-is, and only then does it try converting it to ASCII for a simple match.

Stop trying so hard to match with ASCII string variants -- we can use fuzzywuzzy for that.

These things both simplify the code here and in the caller, and should increase match reliability, especially for non-English media.

Further, this allows unicode in the slot-generator output.  I've tested this with English skills and it works fine there, too.

Complements m0ngr31/kodi-alexa/pull/165