### PR TITLE
Add command for opening Download Subtitles window

### DIFF
--- a/kodi_voice/kodi.py
+++ b/kodi_voice/kodi.py
@@ -737,6 +737,10 @@ class Kodi:
     return self.SendCommand(RPCString("Input.Back"), False)
 
 
+  def DownloadSubtitles(self):
+    return self.SendCommand(RPCString("GUI.ActivateWindow", {"window": "subtitlesearch"}), False)
+
+
   def ShowMovies(self):
     return self.SendCommand(RPCString("GUI.ActivateWindow", {"window": "videos", "parameters": ["MovieTitles", "return"]}), False)
 


### PR DESCRIPTION
Added an RPC command for opening the "Download subtitles" window, where you can download a subtitle from one of your enabled subtitle addons.
(Related to a PR on the kodi-alexa repo: https://github.com/m0ngr31/kodi-alexa/pull/205 )