### PR TITLE
Add caching of responses to an S3 bucket or ownCloud/nextCloud server.

### DIFF
--- a/kodi_voice/cache.py
+++ b/kodi_voice/cache.py
@@ -85,7 +85,7 @@ class KodiCache():
 
       if log.getEffectiveLevel() == logging.DEBUG:
         cache_objs = self.ls()
-        if not len(cache_objs):
+        if not cache_objs:
           log.debug('Object cache empty')
         else:
           log.debug('Objects in cache:')
@@ -96,7 +96,6 @@ class KodiCache():
     else:
       log.info('Disabled')
 
-
   def ls(self):
     listing = []
     if self.enabled:
@@ -105,7 +104,6 @@ class KodiCache():
       elif self.oc:
         listing = [f.get_name() for f in self.oc.list(self.bucket_name)]
     return listing
-
 
   def clear(self):
     if self.enabled:
@@ -121,7 +119,6 @@ class KodiCache():
         self.oc.delete(self.bucket_name)
 
       log.info('Cleared all cache objects')
-
 
   def add(self, cache_file, url, auth, command, timeout, wait_resp=True):
     try:
@@ -156,7 +153,6 @@ class KodiCache():
 
       return resp
 
-
   def get(self, cache_file):
     if self.enabled:
       log.debug('Looking for object %s', cache_file)
@@ -178,3 +174,5 @@ class KodiCache():
       except:
         log.info('No object %s', cache_file)
         pass
+
+    return None

--- a/kodi_voice/cache.py
+++ b/kodi_voice/cache.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+
+import json
+import requests
+import boto3
+import botocore
+import hashlib
+import io
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class KodiCache():
+  def __init__(self, aws_access_key_id=None, aws_secret_access_key=None, bucket_name=None):
+    self.cache_enabled = False
+    self.s3 = None
+
+    log.info('Initalizing')
+    if aws_secret_access_key and aws_access_key_id and bucket_name:
+      self.s3 = boto3.resource('s3', aws_secret_access_key=aws_secret_access_key, aws_access_key_id=aws_access_key_id)
+
+      self.bucket_name = bucket_name
+      log.info('Accessing bucket %s', self.bucket_name)
+      self.bucket = self.s3.Bucket(self.bucket_name)
+
+      try:
+        self.s3.meta.client.head_bucket(Bucket=self.bucket_name)
+      except botocore.exceptions.ClientError as e:
+        log.error('Error %s accessing bucket %s', e.response['Error']['Code'], self.bucket_name)
+        # continue on without the cache
+        pass
+      else:
+        self.cache_enabled = True
+
+        if log.getEffectiveLevel() == logging.DEBUG:
+          objs = self.ls()
+          if not len(objs):
+            log.debug('Object cache empty')
+          else:
+            log.debug('Objects in cache:')
+            for o in objs:
+              log.debug('  %s', o)
+
+    if self.cache_enabled:
+      log.info('Initialized')
+    else:
+      log.info('Disabled')
+
+
+  def ls(self):
+    if self.cache_enabled:
+      return [key.key for key in self.bucket.objects.all()]
+    else:
+      return []
+
+
+  def clear(self):
+    if self.cache_enabled:
+      log.debug('Clearing cache objects')
+      for key in self.bucket.objects.all():
+        key.delete()
+      #bucket.delete()
+      log.info('Cleared all cache objects')
+
+
+  def add(self, cache_file, url, auth, command, timeout, wait_resp=True):
+    try:
+      r = requests.post(url, data=command, auth=auth, timeout=timeout)
+    except requests.exceptions.ReadTimeout:
+      if not wait_resp:
+        # caller doesn't care about the response anyway -- this is mostly for
+        # Player.Open and other methods that can either never fail or we don't
+        # respond any differently if they do.
+        pass
+      else:
+        raise
+    else:
+      if r.encoding is None:
+        r.encoding = 'utf-8'
+
+      try:
+        resp = r.json()
+      except:
+        log.error('JSON decoding failed {}'.format(r))
+        raise
+
+      if self.cache_enabled and cache_file:
+        log.debug('Adding object %s', cache_file)
+        self.s3.Object(self.bucket_name, cache_file).put(Body=json.dumps(resp))
+        log.info('Created/updated object %s', cache_file)
+
+      return resp
+
+
+  def get(self, cache_file):
+    if self.cache_enabled:
+      log.debug('Looking for object %s', cache_file)
+      try:
+        data = io.BytesIO()
+        self.s3.meta.client.download_fileobj(self.bucket_name, cache_file, data)
+        log.debug('Loading object %s', cache_file)
+        r = json.loads(data.getvalue().decode("utf-8"))
+        log.info('Retrieved object %s', cache_file)
+        return r
+      except:
+        log.info('No object %s', cache_file)
+        pass

--- a/kodi_voice/cache.py
+++ b/kodi_voice/cache.py
@@ -4,6 +4,7 @@ import json
 import requests
 import boto3
 import botocore
+import owncloud
 import hashlib
 import io
 import logging
@@ -12,55 +13,113 @@ log = logging.getLogger(__name__)
 
 
 class KodiCache():
-  def __init__(self, aws_access_key_id=None, aws_secret_access_key=None, bucket_name=None):
-    self.cache_enabled = False
+  def __init__(self, bucket_name=None, **kwargs):
+    self.enabled = False
+    self.backend = None
     self.s3 = None
+    self.oc = None
 
     log.info('Initalizing')
-    if aws_secret_access_key and aws_access_key_id and bucket_name:
-      self.s3 = boto3.resource('s3', aws_secret_access_key=aws_secret_access_key, aws_access_key_id=aws_access_key_id)
 
-      self.bucket_name = bucket_name
-      log.info('Accessing bucket %s', self.bucket_name)
-      self.bucket = self.s3.Bucket(self.bucket_name)
+    # Amazon S3 bucket or directory name
+    self.bucket_name = bucket_name
 
-      try:
-        self.s3.meta.client.head_bucket(Bucket=self.bucket_name)
-      except botocore.exceptions.ClientError as e:
-        log.error('Error %s accessing bucket %s', e.response['Error']['Code'], self.bucket_name)
-        # continue on without the cache
-        pass
-      else:
-        self.cache_enabled = True
+    # Amazon credentials for accessing an S3 bucket
+    self.aws_secret_access_key = kwargs.get('aws_secret_access_key', None)
+    self.aws_access_key_id = kwargs.get('aws_access_key_id', None)
 
-        if log.getEffectiveLevel() == logging.DEBUG:
-          objs = self.ls()
-          if not len(objs):
-            log.debug('Object cache empty')
+    # ownCloud/nextCloud credentials
+    self.oc_url = kwargs.get('oc_url', None)
+    self.oc_user = kwargs.get('oc_user', None)
+    self.oc_pass = kwargs.get('oc_password', None)
+
+    if self.bucket_name:
+      # Amazon S3
+      if self.aws_secret_access_key and self.aws_access_key_id:
+        self.s3 = boto3.resource('s3', aws_secret_access_key=self.aws_secret_access_key, aws_access_key_id=self.aws_access_key_id)
+
+        log.info('Accessing bucket %s', self.bucket_name)
+        self.bucket = self.s3.Bucket(self.bucket_name)
+
+        try:
+          self.s3.meta.client.head_bucket(Bucket=self.bucket_name)
+        except botocore.exceptions.ClientError as e:
+          log.error('Error %s accessing bucket %s', e.response['Error']['Code'], self.bucket_name)
+          # continue on without the cache
+          pass
+        else:
+          self.enabled = True
+          self.backend = 'Amazon S3'
+
+      # ownCloud/nextCloud
+      elif self.oc_url and self.oc_user and self.oc_pass:
+        self.oc = owncloud.Client(self.oc_url)
+        self.oc.login(self.oc_user, self.oc_pass)
+
+        if not self.bucket_name[0] == '/':
+          self.bucket_name = '/' + self.bucket_name
+
+        file_info = None
+        try:
+          file_info = self.oc.file_info(self.bucket_name)
+        except owncloud.HTTPResponseError as e:
+          if e.status_code == 404:
+            if self.oc.mkdir(self.bucket_name):
+              file_info = self.oc.file_info(self.bucket_name)
+              pass
+            else:
+              log.error('Could not create cache directory %s', self.bucket_name)
           else:
-            log.debug('Objects in cache:')
-            for o in objs:
-              log.debug('  %s', o)
+            log.error('Error %d accessing directory %s', e.status_code, self.bucket_name)
+            # continue on without the cache
+            pass
 
-    if self.cache_enabled:
-      log.info('Initialized')
+        if isinstance(file_info, owncloud.FileInfo) and not file_info.is_dir():
+          log.error('%s exists, but is not a directory!', self.bucket_name)
+        else:
+          self.enabled = True
+          self.backend = 'ownCloud'
+
+    if self.enabled:
+      assert self.backend is not None
+
+      if log.getEffectiveLevel() == logging.DEBUG:
+        cache_objs = self.ls()
+        if not len(cache_objs):
+          log.debug('Object cache empty')
+        else:
+          log.debug('Objects in cache:')
+          for o in cache_objs:
+            log.debug('  %s', o)
+
+      log.info('Initialized using %s cache backend', self.backend)
     else:
       log.info('Disabled')
 
 
   def ls(self):
-    if self.cache_enabled:
-      return [key.key for key in self.bucket.objects.all()]
-    else:
-      return []
+    listing = []
+    if self.enabled:
+      if self.s3:
+        listing = [key.key for key in self.bucket.objects.all()]
+      elif self.oc:
+        listing = [f.get_name() for f in self.oc.list(self.bucket_name)]
+    return listing
 
 
   def clear(self):
-    if self.cache_enabled:
+    if self.enabled:
       log.debug('Clearing cache objects')
-      for key in self.bucket.objects.all():
-        key.delete()
-      #bucket.delete()
+
+      if self.s3:
+        for key in self.bucket.objects.all():
+          key.delete()
+        #self.bucket.delete()
+      elif self.oc:
+        for f in self.oc.list(self.bucket_name):
+          self.oc.delete(self.bucket_name + '/' + f.get_name())
+        self.oc.delete(self.bucket_name)
+
       log.info('Cleared all cache objects')
 
 
@@ -85,22 +144,35 @@ class KodiCache():
         log.error('JSON decoding failed {}'.format(r))
         raise
 
-      if self.cache_enabled and cache_file:
+      if self.enabled and cache_file:
         log.debug('Adding object %s', cache_file)
-        self.s3.Object(self.bucket_name, cache_file).put(Body=json.dumps(resp))
+
+        if self.s3:
+          self.s3.Object(self.bucket_name, cache_file).put(Body=json.dumps(resp))
+        elif self.oc:
+          self.oc.put_file_contents(self.bucket_name + '/' + cache_file, json.dumps(resp))
+
         log.info('Created/updated object %s', cache_file)
 
       return resp
 
 
   def get(self, cache_file):
-    if self.cache_enabled:
+    if self.enabled:
       log.debug('Looking for object %s', cache_file)
+
       try:
-        data = io.BytesIO()
-        self.s3.meta.client.download_fileobj(self.bucket_name, cache_file, data)
+        cache_obj = None
+
+        if self.s3:
+          data = io.BytesIO()
+          self.s3.meta.client.download_fileobj(self.bucket_name, cache_file, data)
+          cache_obj = data.getvalue()
+        elif self.oc:
+          cache_obj = self.oc.get_file_contents(self.bucket_name + '/' + cache_file)
+
         log.debug('Loading object %s', cache_file)
-        r = json.loads(data.getvalue().decode("utf-8"))
+        r = json.loads(cache_obj.decode("utf-8"))
         log.info('Retrieved object %s', cache_file)
         return r
       except:

--- a/kodi_voice/kodi.config.example
+++ b/kodi_voice/kodi.config.example
@@ -64,11 +64,13 @@ loglevel = INFO
 # devices for mapping to specific instances of Kodi.
 logsensitive = yes
 
+
 # Global Alexa skill configuration
 #
 [alexa]
 # Set skill_id to enable verification of requests by Flask-Ask.
 skill_id =
+
 # Maximum number of items to generate per slot.
 #
 # If the skill is failing to save, you may need to reduce this.  Conversely,
@@ -91,6 +93,15 @@ port     = 8080
 subpath  =
 username = kodi
 password = kodi
+
+# Enable caching of Kodi responses to an Amazon S3 bucket.
+#
+# The bucket must exist before the skill can make use of it.
+#
+# Provide the name of the bucket and an AWS user key and key ID here to enable.
+s3_cache_bucket =
+s3_cache_aws_access_key_id =
+s3_cache_aws_secret_access_key =
 
 # Read timeout -- how long to wait for responses from Kodi before giving up.
 #

--- a/kodi_voice/kodi.config.example
+++ b/kodi_voice/kodi.config.example
@@ -94,14 +94,25 @@ subpath  =
 username = kodi
 password = kodi
 
-# Enable caching of Kodi responses to an Amazon S3 bucket.
+# Caching of Kodi responses.
 #
-# The bucket must exist before the skill can make use of it.
+# Provide an Amazon S3 bucket or a directory name here and provide credentials
+# for one of the cache backends below to enable.
+cache_bucket =
+
+# Amazon S3 cache backend.
 #
-# Provide the name of the bucket and an AWS user key and key ID here to enable.
-s3_cache_bucket =
+# Provide an AWS user key and key ID here to enable.
 s3_cache_aws_access_key_id =
 s3_cache_aws_secret_access_key =
+
+# ownCloud/nextCloud cache backend.
+#
+# Provide the base URL for your ownCloud server and a valid user and password
+# combination to enable.
+owncloud_cache_url =
+owncloud_cache_user =
+owncloud_cache_password =
 
 # Read timeout -- how long to wait for responses from Kodi before giving up.
 #

--- a/kodi_voice/kodi.py
+++ b/kodi_voice/kodi.py
@@ -268,19 +268,19 @@ class KodiConfigParser(SafeConfigParser):
       CACHE_BUCKET = os.getenv('CACHE_BUCKET')
       if CACHE_BUCKET and CACHE_BUCKET != 'None':
         self.set('DEFAULT', 'cache_bucket', CACHE_BUCKET)
-      S3_CACHE_AWS_ACCESS_KEY_ID = os.getenv('s3_cache_aws_access_key_id')
+      S3_CACHE_AWS_ACCESS_KEY_ID = os.getenv('S3_CACHE_AWS_ACCESS_KEY_ID')
       if S3_CACHE_AWS_ACCESS_KEY_ID and S3_CACHE_AWS_ACCESS_KEY_ID != 'None':
         self.set('DEFAULT', 's3_cache_aws_access_key_id', S3_CACHE_AWS_ACCESS_KEY_ID)
-      S3_CACHE_AWS_SECRET_ACCESS_KEY = os.getenv('s3_cache_aws_secret_access_key')
+      S3_CACHE_AWS_SECRET_ACCESS_KEY = os.getenv('S3_CACHE_AWS_SECRET_ACCESS_KEY')
       if S3_CACHE_AWS_SECRET_ACCESS_KEY and S3_CACHE_AWS_SECRET_ACCESS_KEY != 'None':
         self.set('DEFAULT', 's3_cache_aws_secret_access_key', S3_CACHE_AWS_SECRET_ACCESS_KEY)
-      OWNCLOUD_CACHE_URL = os.getenv('owncloud_cache_url')
+      OWNCLOUD_CACHE_URL = os.getenv('OWNCLOUD_CACHE_URL')
       if OWNCLOUD_CACHE_URL and OWNCLOUD_CACHE_URL != 'None':
         self.set('DEFAULT', 'owncloud_cache_url', OWNCLOUD_CACHE_URL)
-      OWNCLOUD_CACHE_USER = os.getenv('owncloud_cache_user')
+      OWNCLOUD_CACHE_USER = os.getenv('OWNCLOUD_CACHE_USER')
       if OWNCLOUD_CACHE_USER and OWNCLOUD_CACHE_USER != 'None':
         self.set('DEFAULT', 'owncloud_cache_user', OWNCLOUD_CACHE_USER)
-      OWNCLOUD_CACHE_PASSWORD = os.getenv('owncloud_cache_password')
+      OWNCLOUD_CACHE_PASSWORD = os.getenv('OWNCLOUD_CACHE_PASSWORD')
       if OWNCLOUD_CACHE_PASSWORD and OWNCLOUD_CACHE_PASSWORD != 'None':
         self.set('DEFAULT', 'owncloud_cache_password', OWNCLOUD_CACHE_PASSWORD)
       READ_TIMEOUT = os.getenv('READ_TIMEOUT')

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ setup(
   keywords = ['kodi', 'voice', 'alexa'],
   classifiers = [],
   download_url = 'https://github.com/m0ngr31/kodi-voice/tarball/1.0.0',
-  install_requires = ['requests', 'boto3', 'ConfigParser', 'num2words', 'roman', 'fuzzywuzzy']
+  install_requires = ['requests', 'boto3', 'pyocclient', 'ConfigParser', 'num2words', 'roman', 'fuzzywuzzy']
 )

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ setup(
   keywords = ['kodi', 'voice', 'alexa'],
   classifiers = [],
   download_url = 'https://github.com/m0ngr31/kodi-voice/tarball/1.0.0',
-  install_requires = ['requests', 'ConfigParser', 'num2words', 'roman', 'fuzzywuzzy']
+  install_requires = ['requests', 'boto3', 'ConfigParser', 'num2words', 'roman', 'fuzzywuzzy']
 )


### PR DESCRIPTION
Allows the user to provide credentials to store responses from Kodi in an S3 bucket or a directory on an ownCloud/nextCloud server, which should in theory be faster to retrieve than from Kodi itself if the user has a slow uplink and/or a slow database backend.

If a given cache object exists, this will fetch it from a configured Amazon S3 bucket or directory on an ownCloud/nextCloud server and return it to Alexa immediately.  Then, in the background, it will query Kodi for the response to re-cache it.

If a cache object doesn't exist, it will block waiting for the response from Kodi and then cache the object before returning.

Not everything can be cached.  Particularly, it will not attempt to cache anything that always needs fresh data by nature ('what is playing,' 'play the next episode of x,' etc).  It also will not cache responses that are either or both generally pretty small and have a tendency to be updated by the user outside of a library update (installed addons, playlists, etc).  Finally, all fire-and-forget commands will obviously not be cached because we ignore the response for those anyway.

The cache needs to be invalidated on library updates.  I've implemented this in the clean library and update library Intents.  This means it depends on the user using the voice commands to update and clean their libraries, which isn't totally ideal, but should be OK if we document it.

This does work with multiple instances of Kodi as well (even with just one bucket/directory configured) because I'm hashing the command with the url to generate the file names.  But, the bucket/directory and its credentials can be overridden in the device mapping sections of the config, thus allowing multiple buckets/directories to be used.  Those with multiple, distinct libraries may want to use this feature.

On a library update/clean, it will wipe _all_ cache objects in the configured bucket/directory for the associated device, including those of other Kodi targets that don't have their own cache buckets/directories configured (i.e., using the _DEFAULT_ config).  The reason for this is I can't tell if the library is shared with other Kodi clients, and it would be annoying to have to update library on all clients that share the same library.

Heroku users only have access to one bucket/directory, since it doesn't support device mapping.

This has been released on the test PyPi server as [Kodi-Voice 10.9.37](https://testpypi.python.org/pypi/Kodi-Voice/10.9.37)

To test, install Kodi-Voice from the test server:

`pip install --index-url https://test.pypi.org/simple/ Kodi-Voice=10.9.37`

Add the following to your kodi.config under the _DEFAULT_ section and/or each device section to enable caching in Amazon S3 bucket(s):

```
cache_bucket =
s3_cache_aws_access_key_id =
s3_cache_aws_secret_access_key =
```

And for ownCloud/nextCloud:

```
cache_bucket =
owncloud_cache_url =
owncloud_cache_user =
owncloud_cache_password =
```

For Amazon S3 buckets, you'll need to create the buckets beforehand.  For ownCloud/nextCloud, it will automatically create the buckets.

If both S3 and ownCloud are specified, it will prioritize the S3 configuration.

It is possible to override these in the device sections, so you can use different buckets for each device.  This is useful because an update/clean library request will clear everything in a given bucket, so if you have multiple libraries, you can limit the wipe to only the bucket associated with the device that requested the clear.

_Needs changes in Kodi-Alexa for Heroku (see m0ngr31/kodi-alexa/pull/227)_